### PR TITLE
The 'Twig_Extension' and 'Twig_SimpleFunction' class are deprecated

### DIFF
--- a/Twig/GlideExtension.php
+++ b/Twig/GlideExtension.php
@@ -2,9 +2,11 @@
 
 namespace Erichard\Bundle\GlideBundle\Twig;
 
+use Twig\TwigFunction;
+use Twig\Extension\AbstractExtension;
 use Erichard\Bundle\GlideBundle\GlideUrlBuilderInterface;
 
-class GlideExtension extends \Twig_Extension
+class GlideExtension extends AbstractExtension
 {
     /** @var GlideUrlBuilderInterface */
     protected $glideUrlBuilder;
@@ -17,7 +19,7 @@ class GlideExtension extends \Twig_Extension
     public function getFunctions()
     {
         return [
-            new \Twig_SimpleFunction('glideUrl', [$this, 'glideUrl']),
+            new TwigFunction('glideUrl', [$this, 'glideUrl']),
         ];
     }
 


### PR DESCRIPTION
The `Twig_Extension` and `Twig_SimpleFunction` class are deprecated, they are replaced by `Twig\Extension\AbstractExtension` and `Twig\TwigFunction`.

![Capture d’écran de 2021-02-02 12-38-21](https://user-images.githubusercontent.com/29166550/106573841-94519e80-6553-11eb-8fac-f1f1a4593f6c.png)
